### PR TITLE
erc warnings

### DIFF
--- a/Komar.brd
+++ b/Komar.brd
@@ -6295,7 +6295,7 @@ by Télega</text>
 <element name="CON8" library="pinhead" library_urn="urn:adsk.eagle:library:2540341" package="1X04-PTH-2" package3d_urn="urn:adsk.eagle:package:4854340/4" value="PINHEAD_1X04-2" x="25.2" y="53.5" smashed="yes"/>
 <element name="CON10" library="pinhead" library_urn="urn:adsk.eagle:library:2540341" package="1X01-PTH-2" package3d_urn="urn:adsk.eagle:package:2540397/4" value="PINHEAD_1X01-2" x="19.5" y="49.4" smashed="yes"/>
 <element name="CON11" library="pinhead" library_urn="urn:adsk.eagle:library:2540341" package="1X01-PTH-2" package3d_urn="urn:adsk.eagle:package:2540397/4" value="PINHEAD_1X01-2" x="22.5" y="49.4" smashed="yes"/>
-<element name="CON12" library="pinhead" library_urn="urn:adsk.eagle:library:2540341" package="1X01-PTH-2" package3d_urn="urn:adsk.eagle:package:2540397/4" value="PINHEAD_1X01-2" x="25.5" y="49.4" smashed="yes"/>
+<element name="CON12" library="pinhead" library_urn="urn:adsk.eagle:library:2540341" package="1X01-PTH-2" package3d_urn="urn:adsk.eagle:package:2540397/4" value="PINHEAD_1X01-2" x="25.61" y="49.39" locked="yes" smashed="yes"/>
 <element name="CON13" library="pinhead" library_urn="urn:adsk.eagle:library:2540341" package="1X01-PTH-2" package3d_urn="urn:adsk.eagle:package:2540397/4" value="PINHEAD_1X01-2" x="17.5" y="8.6" smashed="yes"/>
 <element name="CON14" library="pinhead" library_urn="urn:adsk.eagle:library:2540341" package="1X01-PTH-2" package3d_urn="urn:adsk.eagle:package:2540397/4" value="PINHEAD_1X01-2" x="20.5" y="8.6" smashed="yes"/>
 <element name="CON15" library="pinhead" library_urn="urn:adsk.eagle:library:2540341" package="1X01-PTH-2" package3d_urn="urn:adsk.eagle:package:2540397/4" value="PINHEAD_1X01-2" x="28.5" y="49.4" smashed="yes"/>
@@ -8556,8 +8556,8 @@ by Télega</text>
 <approved hash="3,1,620dc975c9aa62d2"/>
 <approved hash="19,1,8d26e99d6f2395b4"/>
 <approved hash="19,1,0aa728e9dd9a963c"/>
-<approved hash="5,1,dbbdc85340f7730b"/>
 <approved hash="23,1,60c13b0300879079"/>
+<approved hash="5,1,dbbdc85340f7730b"/>
 </errors>
 </board>
 </drawing>

--- a/Komar.sch
+++ b/Komar.sch
@@ -8179,9 +8179,20 @@ http://www.pcblibraries.com/downloads/temp/ANSI_Wire_Gauge_Charts_6433393.pdf</t
 </sheet>
 </sheets>
 <errors>
-<approved hash="104,2,22.86,106.68,MODULE1,5V_OUT,VDD_5V,,,"/>
-<approved hash="202,2,88.9,40.64,MODULE1,POWER_ENABLE_IN,,,,"/>
+<approved hash="101,2,261.62,15.24,CON10,1,,,,"/>
+<approved hash="101,2,251.46,15.24,CON11,1,,,,"/>
+<approved hash="101,2,241.3,15.24,CON12,1,,,,"/>
+<approved hash="101,2,231.14,15.24,CON13,1,,,,"/>
+<approved hash="101,2,220.98,15.24,CON14,1,,,,"/>
+<approved hash="101,2,210.82,15.24,CON15,1,,,,"/>
+<approved hash="104,2,22.86,106.68,MODULE2,5V_OUT,VDD_5V,,,"/>
+<approved hash="202,2,88.9,40.64,MODULE2,POWER_ENABLE_IN,,,,"/>
+<approved hash="110,2,360.68,50.8,N$46,N$44,,,,"/>
+<approved hash="110,2,360.68,50.8,N$46,N$44,,,,"/>
+<approved hash="110,2,360.68,116.84,N$21,N$22,,,,"/>
+<approved hash="110,2,360.68,116.84,N$21,N$22,,,,"/>
 <approved hash="113,2,193.571,130.071,FRAME1,,,,,"/>
+<approved hash="113,1,91.971,66.571,FRAME2,,,,,"/>
 </errors>
 </schematic>
 </drawing>


### PR DESCRIPTION
Before we release the manufacturing documentation and generate gerbers, all the DRC and ERC errors should be resolved and all the warnings should be checked and acknowledged. 