### PR TITLE
Increase the hardware over-current protection limit; remove incorrect alternative part number

### DIFF
--- a/Komar.brd
+++ b/Komar.brd
@@ -6166,7 +6166,6 @@ by Télega</text>
 </element>
 <element name="D7" library="Diodes" library_urn="urn:adsk.eagle:library:2473263" package="SOT363" package3d_urn="urn:adsk.eagle:package:1040203/3" value="BAV99HDWQ-13" x="17.1" y="45.525" smashed="yes" rot="R90">
 <attribute name="AEC-Q" value="AEC-Q101" x="17.1" y="45.525" size="1.778" layer="27" rot="R90" display="off"/>
-<attribute name="ALTERNATIVE" value="BAV70HDWQ-13" x="17.1" y="45.525" size="1.778" layer="27" rot="R90" display="off"/>
 <attribute name="DIGIKEY#" value="BAV99HDWQ-13DICT-ND" x="19.475" y="42.95" size="1.778" layer="27" rot="R90" display="off"/>
 <attribute name="MANF" value="Diodes Incorporated" x="19.475" y="42.95" size="1.778" layer="27" rot="R90" display="off"/>
 <attribute name="MANF#" value="BAV99HDWQ-13" x="19.475" y="42.95" size="1.778" layer="27" rot="R90" display="off"/>

--- a/Komar.brd
+++ b/Komar.brd
@@ -6124,11 +6124,11 @@ by Télega</text>
 <attribute name="NAME" x="34.7" y="51.3" size="1.27" layer="25" font="vector" ratio="15" align="center"/>
 <attribute name="REVERS_STANDOFF_V" value="51V" x="34.7" y="51.3" size="1.778" layer="27" display="off"/>
 </element>
-<element name="R7" library="rc" library_urn="urn:adsk.eagle:library:2539423" package="R0402" package3d_urn="urn:adsk.eagle:package:2539456/2" value="1K5" x="6.95" y="34.9" smashed="yes" rot="MR180">
+<element name="R7" library="rc" library_urn="urn:adsk.eagle:library:2539423" package="R0402" package3d_urn="urn:adsk.eagle:package:2539456/2" value="16K" x="6.95" y="34.9" smashed="yes" rot="MR180">
 <attribute name="AEC-Q" value="AEC-Q200" x="6.95" y="34.9" size="1.778" layer="28" rot="MR180" display="off"/>
-<attribute name="DIGIKEY#" value="P1.50KLCT-ND" x="6.95" y="34.9" size="1.778" layer="28" rot="MR180" display="off"/>
+<attribute name="DIGIKEY#" value="P124444CT-ND" x="6.95" y="34.9" size="1.778" layer="28" rot="MR180" display="off"/>
 <attribute name="MANF" value="Panasonic Electronic Components" x="6.95" y="34.9" size="1.778" layer="28" rot="MR180" display="off"/>
-<attribute name="MANF#" value="ERJ-2RKF1501X" x="6.95" y="34.9" size="1.778" layer="28" rot="MR180" display="off"/>
+<attribute name="MANF#" value="ERJ-PA2F1602X" x="6.95" y="34.9" size="1.778" layer="28" rot="MR180" display="off"/>
 <attribute name="NAME" x="6.95" y="34.9" size="0.5" layer="26" font="vector" ratio="15" rot="MR180" align="center"/>
 <attribute name="PACKAGE" value="0402" x="6.95" y="34.9" size="1.778" layer="28" rot="MR180" display="off"/>
 <attribute name="TOLERANCE" value="1%" x="6.95" y="34.9" size="1.778" layer="28" rot="MR180" display="off"/>

--- a/Komar.sch
+++ b/Komar.sch
@@ -5689,11 +5689,11 @@ DIN A3, landscape with location and doc. field</description>
 <attribute name="ASSY" value="DNM"/>
 <variant name="BASIC" populate="no"/>
 </part>
-<part name="R7" library="rc" library_urn="urn:adsk.eagle:library:2539423" deviceset="R" device="-0402" package3d_urn="urn:adsk.eagle:package:2539456/2" technology="-1%" value="1K5">
+<part name="R7" library="rc" library_urn="urn:adsk.eagle:library:2539423" deviceset="R" device="-0402" package3d_urn="urn:adsk.eagle:package:2539456/2" technology="-1%" value="16K">
 <attribute name="AEC-Q" value="AEC-Q200"/>
-<attribute name="DIGIKEY#" value="P1.50KLCT-ND"/>
+<attribute name="DIGIKEY#" value="P124444CT-ND"/>
 <attribute name="MANF" value="Panasonic Electronic Components"/>
-<attribute name="MANF#" value="ERJ-2RKF1501X"/>
+<attribute name="MANF#" value="ERJ-PA2F1602X"/>
 </part>
 <part name="GND5" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GND" device="" value="GND"/>
 <part name="GND38" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GND" device="" value="GND"/>

--- a/Komar.sch
+++ b/Komar.sch
@@ -5722,9 +5722,7 @@ DIN A3, landscape with location and doc. field</description>
 <attribute name="MANF#" value="ERJ-2GEJ201X"/>
 <attribute name="OPERATING_TEMP" value="-55°C ~ 155°C"/>
 </part>
-<part name="D7" library="Diodes" library_urn="urn:adsk.eagle:library:2473263" deviceset="BAV99HDWQ-13" device="" package3d_urn="urn:adsk.eagle:package:1040203/3">
-<attribute name="ALTERNATIVE" value="BAV70HDWQ-13"/>
-</part>
+<part name="D7" library="Diodes" library_urn="urn:adsk.eagle:library:2473263" deviceset="BAV99HDWQ-13" device="" package3d_urn="urn:adsk.eagle:package:1040203/3"/>
 <part name="GND40" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GND" device="" value="GND"/>
 <part name="+P21" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="5V" device=""/>
 <part name="GND45" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GND" device="" value="GND"/>
@@ -6633,7 +6631,6 @@ http://www.pcblibraries.com/downloads/temp/ANSI_Wire_Gauge_Charts_6433393.pdf</t
 <instance part="D7" gate="D1" x="223.52" y="38.1" smashed="yes" rot="MR90">
 <attribute name="NAME" x="223.52" y="35.052" size="1.27" layer="95" font="vector" ratio="15" rot="MR180" align="center"/>
 <attribute name="MANF#" x="223.52" y="36.322" size="0.762" layer="95" font="vector" ratio="15" rot="MR0" align="center"/>
-<attribute name="ALTERNATIVE" x="223.52" y="38.1" size="1.778" layer="96" rot="MR90" display="off"/>
 </instance>
 <instance part="D7" gate="D2" x="205.74" y="38.1" smashed="yes" rot="MR90">
 <attribute name="NAME" x="205.74" y="35.052" size="1.27" layer="95" font="vector" ratio="15" rot="MR180" align="center"/>

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Newest entries at the top.
 
 ### Komar V1.4 (January 2023)
 
+* Removed alternative for Diode BAV99HDWQ-13.
 * Increased the hardware over-current protection trip level to 427A.
 
 ### Komar V1.3 (November 2022)
@@ -125,8 +126,8 @@ Newest entries at the top.
 | Part               | Alternative       | Function          |
 | -------------------| ------------------| ------------------|
 | ATA6561-GBQW-N     | TJA1441DTK/0Z     | CAN TRANSCEIVER   |
-| BAV99HDWQ-13       | BAV70HDWQ-13      | DIODE             |
 | FDMS86368-F085     | BSC080N12LSGATMA1 | FET               |
+| BAV99HDWQ-13       | BAV70HDWQ-13      | DIODE             |
 | MCP9700AT-E/TTVAO  | MCP9701T-E/TT     | THERMISTOR        |
 | ELXZ630ELL331MK20S | EEU-FC1J331B      | CAPACITOR         |
 | NRVB120VLSFT1G     | NRVB230LSFT1G     | DIODE             |

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ The most up-to-date documentation is attached to the latest published
 
 Newest entries at the top.
 
+### Komar V1.4 (January 2023)
+
+* Increased the hardware over-current protection trip level to 427A.
+
 ### Komar V1.3 (November 2022)
 
 * Changed DC/Battery power wire to 12 AWG in the assembly manual.


### PR DESCRIPTION
changed R7 from ERJ-2RKF1501X to ERJ-PA2F1602X.