### PR TITLE
updated thermistor alternative

### DIFF
--- a/Komar.brd
+++ b/Komar.brd
@@ -5459,7 +5459,7 @@ by Télega</text>
 </element>
 <element name="IC5" library="misc" library_urn="urn:adsk.eagle:library:5347860" package="SOT23B-3" package3d_urn="urn:adsk.eagle:package:1040193/4" value="MCP9700AT-E/TTVAO-SOT23" x="28.675" y="46.1" smashed="yes">
 <attribute name="AEC-Q" value="AEC-Q100" x="28.675" y="46.1" size="1.778" layer="27" display="off"/>
-<attribute name="ALTERNATIVE" value="MCP9701T-E/TT" x="28.675" y="46.1" size="1.778" layer="27" display="off"/>
+<attribute name="ALTERNATIVE" value="MCP9700T-E/TT" x="28.675" y="46.1" size="1.778" layer="27" display="off"/>
 <attribute name="DIGIKEY#" value="MCP9700AT-E/TTVAOTR-ND" x="-38.325" y="111.1" size="1.778" layer="27" display="off"/>
 <attribute name="MANF" value="Microchip Technology" x="-38.325" y="111.1" size="1.778" layer="27" display="off"/>
 <attribute name="MANF#" value="MCP9700AT-E/TTVAO" x="-38.325" y="111.1" size="1.778" layer="27" display="off"/>

--- a/Komar.sch
+++ b/Komar.sch
@@ -5196,7 +5196,7 @@ DIN A3, landscape with location and doc. field</description>
 <attribute name="POWER" value="3W"/>
 </part>
 <part name="IC5" library="misc" library_urn="urn:adsk.eagle:library:5347860" deviceset="MCP9700" device="-SOT23" package3d_urn="urn:adsk.eagle:package:1040193/4" technology="AT-E/TTVAO">
-<attribute name="ALTERNATIVE" value="MCP9701T-E/TT"/>
+<attribute name="ALTERNATIVE" value="MCP9700T-E/TT"/>
 </part>
 <part name="GND28" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GND" device="" value="GND"/>
 <part name="R27" library="rc" library_urn="urn:adsk.eagle:library:2539423" deviceset="R" device="-0402" package3d_urn="urn:adsk.eagle:package:2539456/2" technology="-5%" value="200R">

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ The most up-to-date documentation is attached to the latest published
 
 Newest entries at the top.
 
+### Komar V1.5 (January 2023)
+
+* Updated alternative for MCP9700AT-E/TTVAO to MCP9700T-E/TT.
+
 ### Komar V1.4 (January 2023)
 
 * Removed alternative for Diode BAV99HDWQ-13.


### PR DESCRIPTION
changed MCP9701T-E/TT to MCP9700T-E/TT - correct alternative part number
closes #44 